### PR TITLE
feat: always preserve json-rpc errors

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -1,13 +1,9 @@
 var create = require('ut-error').define;
 
-var RPC = create('PortRPC');
-var Generic = create('Generic', RPC);
-var WrongJsonRpcFormat = create('WrongJsonRpcFormat', RPC);
+var Generic = create('PortRPC');
+var WrongJsonRpcFormat = create('WrongJsonRpcFormat', Generic);
 
 module.exports = {
-    rpc: function(cause) {
-        return new RPC(cause);
-    },
     generic: function(cause) {
         return new Generic(cause);
     },

--- a/errors.js
+++ b/errors.js
@@ -8,11 +8,11 @@ var plainError = cause => Object.assign(new Error(), cause);
 
 module.exports = {
     rpc: function(cause) {
-        var method = RPC;
+        var error = RPC;
         if (cause && cause.type) {
-            method = utError.get(cause.type) || plainError;
+            error = utError.get(cause.type) || plainError;
         }
-        return method(cause);
+        return error(cause);
     },
     generic: function(cause) {
         return new Generic(cause);

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function JsonRpcPort() {
                     }
                     return msg.payload.result;
                 } else if (msg.payload.error) {
-                    throw errors.rpc(msg.payload.error);
+                    throw Object.assign(new Error(), msg.payload.error);
                 }
                 throw errors.wrongJsonRpcFormat(msg);
             }


### PR DESCRIPTION
preserve error format (type, message and errorPrint) when receiving json-rpc errors.