### PR TITLE
fix: move dependency to ut-port-http from peerDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "lodash.merge": "4.6.0"
   },
   "devDependencies": {
+    "ut-port-http": "^6.4.1",
     "ut-tools": "^5.13.5"
   },
   "peerDependencies": {
-    "ut-port-http": "^6.4.1",
     "ut-bus": "^5.9.0"
   },
   "description": "UT port rpc module",


### PR DESCRIPTION
ut-port-http is required directly in index.js. It is not necessary ut-port-http to be a dependency of another module or implementation